### PR TITLE
[TASK] Fix XML Templates

### DIFF
--- a/output.json
+++ b/output.json
@@ -5,18 +5,6 @@
       "write_to": "res/values/colors.xml"
     },
     {
-      "invoke": "dimens.xml.pr",
-      "write_to": "res/values/dimens.xml"
-    },
-    {
-      "invoke": "text_styles.xml.pr",
-      "write_to": "res/values/text_styles.xml"
-    },
-    {
-      "invoke": "radii.xml.pr",
-      "write_to": "res/values/radii.xml"
-    },
-    {
       "invoke": "ColorTokens.kt.pr",
       "write_using": "color_tokens_path.pr"
     },

--- a/output.json
+++ b/output.json
@@ -2,7 +2,7 @@
   "blueprints": [
     {
       "invoke": "colors.xml.pr",
-      "write_to": "res/values/colors.xml"
+      "write_using": "color_tokens_res_path.pr"
     },
     {
       "invoke": "ColorTokens.kt.pr",

--- a/src/templates/configuration/output/color_tokens_res_path.pr
+++ b/src/templates/configuration/output/color_tokens_res_path.pr
@@ -1,0 +1,1 @@
+{[ inject "res_root" context "colors" /]}

--- a/src/templates/configuration/res_root.pr
+++ b/src/templates/configuration/res_root.pr
@@ -1,0 +1,2 @@
+{[ const tokenType = context /]}
+res/values/{{ tokenType }}.xml

--- a/src/templates/xml/colors.xml.pr
+++ b/src/templates/xml/colors.xml.pr
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
 {[ const brand = ds.currentBrand() /]}
 {[ const colorTokensTree = ds.tokenGroupTreeByType("Color", brand.id) /]}
 {[ traverse colorTokensTree property subgroups into colorTokenGroup ]}
   {[ let fullTokenGroupPath = createFullTokenGroupPath(colorTokenGroup) /]}
-  {[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id) /]}
+  {[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id).filterComponentTokens() /]}
+  {[ if (colorTokenInGroups.count() !== 0)]}
+
+  {[/]}
   {[ for colorToken in colorTokenInGroups ]}
     {[ const fullTokenPath = fullTokenGroupPath.aconcat(colorToken.name) /]}
     {[ const fullTokenName = fullTokenPath.ajoin(" ") /]}
     {[ if (colorToken.description && colorToken.description !== "") ]}
-    <!-- 
-        {{ colorToken.description.indentMultiline("        ") }} 
+    <!--
+        {{ colorToken.description.indentMultiline("        ") }}
     -->
     {[/]}
     <color name="{[ inject "export_snakecased_token_name" context fullTokenName /]}">{[ inject "export_color_value" context colorToken.value /]}</color>
-    {[/]}
-
-
+  {[/]}
 {[/]}
-
 </resources>

--- a/src/templates/xml/utility/export_color_value.pr
+++ b/src/templates/xml/utility/export_color_value.pr
@@ -1,5 +1,2 @@
-{[ const alpha = context.hex.substring(6, 2) /]}
-{[ const red = context.hex.substring(0, 2) /]}
-{[ const green = context.hex.substring(2, 2) /]}
-{[ const blue = context.hex.substring(4, 2) /]}
-#{{alpha}}{{red}}{{green}}{{blue}}
+{[ const argb = hexARGB(context) /]}
+#{{argb.alpha}}{{argb.red}}{{argb.green}}{{argb.blue}}


### PR DESCRIPTION
This fixes the formatting (mainly whitespace) of the `colors.xml` file, removes the currently unsupported token type files (dimens, etc) and removes the component tokens from being generated in the XML files, because we don't want to support them in XML.