### PR TITLE
[TASK] Remove Gradient Offsets

### DIFF
--- a/src/templates/compose/single/Brush.kt.pr
+++ b/src/templates/compose/single/Brush.kt.pr
@@ -5,6 +5,4 @@ Brush.{{ brushType(token) }}(
         {{ stop.position }}f to {[ inject "Color.kt" context stop.color /]},
         {[/]}
     ),
-    start = Offset(x = {{ token.from.x.toFixed() }}f, y = {{ token.from.y.toFixed() }}f),
-    end = Offset(x = {{ token.to.x.toFixed() }}f, y = {{ token.to.y.toFixed() }}f),
 )


### PR DESCRIPTION
The offsets from the token were messing up the usability of the gradients. Just remove them because they're not really used 🤷 